### PR TITLE
Support screen share feature from client-js 0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ let voiceClient = new RTVIClient({
 await voiceClient.start()
 ```
 
-If you wish to enable screen sharing on iOS or Android, you must first follow the instructions outlined in the Daily Framework RN Screen Share extension [here](https://github.com/daily-co/rn-screen-share-extension/).
+> Note: To enable screen sharing on iOS, follow the instructions in the [Daily Framework RN Screen Share extension](https://github.com/daily-co/rn-screen-share-extension/).
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ let voiceClient = new RTVIClient({
 await voiceClient.start()
 ```
 
+If you wish to enable screen sharing on iOS or Android, you must first follow the instructions outlined in the Daily Framework RN Screen Share extension [here](https://github.com/daily-co/rn-screen-share-extension/).
+
+
 ## Documentation
 
 Pipecat Client React Native implements a client instance that:

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     ]
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^0.3.1"
+    "@pipecat-ai/client-js": "^0.3.2"
   },
   "peerDependencies": {
     "@daily-co/react-native-webrtc": "^118.0.3-daily.2",

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -3,6 +3,7 @@ import Daily, {
   DailyEventObjectAppMessage,
   DailyEventObjectAvailableDevicesUpdated,
   DailyEventObjectLocalAudioLevel,
+  DailyEventObjectNonFatalError,
   DailyEventObjectParticipant,
   DailyEventObjectParticipantLeft,
   DailyEventObjectRemoteParticipantsAudioLevel,
@@ -147,6 +148,18 @@ export class RNDailyTransport extends Transport {
     return this._daily!.localVideo();
   }
 
+  enableScreenShare(enable: boolean) {
+    if (enable) {
+      this._daily!.startScreenShare();
+    } else {
+      this._daily!.stopScreenShare();
+    }
+  }
+
+  get isSharingScreen(): boolean {
+    return this._daily!.localScreenAudio() || this._daily!.localScreenVideo();
+  }
+
   tracks() {
     const participants = this._daily?.participants();
     const bot = participants?.[this._botId];
@@ -154,6 +167,8 @@ export class RNDailyTransport extends Transport {
     const tracks: Tracks = {
       local: {
         audio: participants?.local?.tracks?.audio?.persistentTrack,
+        screenAudio: participants?.local?.tracks?.screenAudio?.persistentTrack,
+        screenVideo: participants?.local?.tracks?.screenVideo?.persistentTrack,
         video: participants?.local?.tracks?.video?.persistentTrack,
       },
     };
@@ -272,6 +287,7 @@ export class RNDailyTransport extends Transport {
     );
     this._daily!.on("app-message", this.handleAppMessage.bind(this));
     this._daily!.on("left-meeting", this.handleLeftMeeting.bind(this));
+    this._daily!.on("nonfatal-error", this.handleNonFatalError.bind(this));
   }
 
   async disconnect() {
@@ -324,17 +340,39 @@ export class RNDailyTransport extends Transport {
   }
 
   private handleTrackStarted(ev: DailyEventObjectTrack) {
-    this._callbacks.onTrackStarted?.(
-      ev.track,
-      ev.participant ? dailyParticipantToParticipant(ev.participant) : undefined
-    );
+    if (ev.type === "screenAudio" || ev.type === "screenVideo") {
+      this._callbacks.onScreenTrackStarted?.(
+        ev.track,
+        ev.participant
+          ? dailyParticipantToParticipant(ev.participant)
+          : undefined
+      );
+    } else {
+      this._callbacks.onTrackStarted?.(
+        ev.track,
+        ev.participant
+          ? dailyParticipantToParticipant(ev.participant)
+          : undefined
+      );
+    }
   }
 
   private handleTrackStopped(ev: DailyEventObjectTrack) {
-    this._callbacks.onTrackStopped?.(
-      ev.track,
-      ev.participant ? dailyParticipantToParticipant(ev.participant) : undefined
-    );
+    if (ev.type === "screenAudio" || ev.type === "screenVideo") {
+      this._callbacks.onScreenTrackStopped?.(
+        ev.track,
+        ev.participant
+          ? dailyParticipantToParticipant(ev.participant)
+          : undefined
+      );
+    } else {
+      this._callbacks.onTrackStopped?.(
+        ev.track,
+        ev.participant
+          ? dailyParticipantToParticipant(ev.participant)
+          : undefined
+      );
+    }
   }
 
   private handleParticipantJoined(ev: DailyEventObjectParticipant) {
@@ -388,6 +426,14 @@ export class RNDailyTransport extends Transport {
     this.state = "disconnected";
     this._botId = "";
     this._callbacks.onDisconnected?.();
+  }
+
+  private handleNonFatalError(ev: DailyEventObjectNonFatalError) {
+    switch (ev.type) {
+      case "screen-share-error":
+        this._callbacks.onScreenShareError?.(ev.errorMsg);
+        break;
+    }
   }
 
   get expiry(): number | undefined {

--- a/src/types/@pipecat-ai/client-js/typeOverrides.d.ts
+++ b/src/types/@pipecat-ai/client-js/typeOverrides.d.ts
@@ -127,9 +127,13 @@ export type Tracks = {
   local: {
     audio?: MediaStreamTrack;
     video?: MediaStreamTrack;
+    screenAudio?: MediaStreamTrack;
+    screenVideo?: MediaStreamTrack;
   };
   bot?: {
     audio?: MediaStreamTrack;
+    screenAudio?: undefined;
+    screenVideo?: undefined;
     video?: MediaStreamTrack;
   };
 };
@@ -156,8 +160,10 @@ export abstract class Transport {
     abstract get selectedSpeaker(): MediaDeviceInfo | Record<string, never>;
   abstract enableMic(enable: boolean): void;
   abstract enableCam(enable: boolean): void;
+  abstract enableScreenShare(enable: boolean): void;
   abstract get isCamEnabled(): boolean;
   abstract get isMicEnabled(): boolean;
+  abstract get isSharingScreen(): boolean;
   abstract sendMessage(message: RTVIMessage): void;
   abstract get state(): TransportState;
   abstract set state(state: TransportState);
@@ -177,6 +183,9 @@ export enum RTVIEvent {
   ParticipantLeft = "participantLeft",
   TrackStarted = "trackStarted",
   TrackStopped = "trackStopped",
+  ScreenTrackStarted = "screenTrackStarted",
+  ScreenTrackStopped = "screenTrackStopped",
+  ScreenShareError = "screenShareError",
   AvailableCamsUpdated = "availableCamsUpdated",
   AvailableMicsUpdated = "availableMicsUpdated",
   AvailableSpeakersUpdated = "availableSpeakersUpdated",
@@ -218,6 +227,9 @@ export type RTVIEvents = Partial<{
   participantLeft: (participant: Participant) => void;
   trackStarted: (track: MediaStreamTrack, participant?: Participant) => void;
   trackStopped: (track: MediaStreamTrack, participant?: Participant) => void;
+  screenTrackStarted: (track: MediaStreamTrack, p?: Participant) => void;
+  screenTrackStopped: (track: MediaStreamTrack, p?: Participant) => void;
+  screenShareError: (errorMessage: string) => void;
   availableCamsUpdated: (cams: MediaDeviceInfo[]) => void;
   availableMicsUpdated: (mics: MediaDeviceInfo[]) => void;
   availableSpeakersUpdated: (speakers: MediaDeviceInfo[]) => void;
@@ -282,10 +294,10 @@ export type RTVIClientConfigOption = {
 };
 export type RTVIURLEndpoints = "connect" | "action";
 export type RTVIClientParams = {
-  baseUrl: string;
+  baseUrl?: string | null;
 } & Partial<{
   headers?: Headers;
-  endpoints: Record<RTVIURLEndpoints, string>;
+  endpoints: Record<RTVIURLEndpoints, string | null>;
   requestData?: object;
   config?: RTVIClientConfigOption[];
 }> & {
@@ -386,6 +398,15 @@ export type RTVIEventCallbacks = Partial<{
     onSpeakerUpdated: (speaker: MediaDeviceInfo) => void;
   onTrackStarted: (track: MediaStreamTrack, participant?: Participant) => void;
   onTrackStopped: (track: MediaStreamTrack, participant?: Participant) => void;
+  onScreenTrackStarted: (
+    track: MediaStreamTrack,
+    participant?: Participant
+  ) => void;
+  onScreenTrackStopped: (
+    track: MediaStreamTrack,
+    participant?: Participant
+  ) => void;
+  onScreenShareError: (errorMessage: string) => void;
   onLocalAudioLevel: (level: number) => void;
   onRemoteAudioLevel: (level: number, participant: Participant) => void;
     onBotStartedSpeaking: () => void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,10 +1431,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pipecat-ai/client-js@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@pipecat-ai/client-js/-/client-js-0.3.1.tgz#d2178d78f8db854b2410ebdcf308275a868195ef"
-  integrity sha512-qUcZKPXP4rYzEZcNDVtCDj6RhieTYutFgF0hnC/v6Jq1T2KY9XrKrrioXY5wO1MlWRo2CzUvLDFfKw/KOWS9yA==
+"@pipecat-ai/client-js@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@pipecat-ai/client-js/-/client-js-0.3.2.tgz#526dae2afc5812b597336893ad2d28220b49bc3a"
+  integrity sha512-psunOVrJjPka2SWlq53vxVWCA0Vt8pSXsXtn8pOLC0YTKFsUx+b7Z6quYUJcDZjCe1aAg9cKETek3Xal3Co8Tg==
   dependencies:
     "@types/events" "^3.0.3"
     clone-deep "^4.0.1"


### PR DESCRIPTION
Resolves https://github.com/pipecat-ai/pipecat-client-react-native-daily-transport/issues/9

Bumping `"@pipecat-ai/client-js` to `0.3.2` in order to enable the [new screen share feature](https://github.com/pipecat-ai/pipecat-client-web/pull/93).

Based these changes on the work that was done for the web client transports [here](https://github.com/pipecat-ai/pipecat-client-web-transports/pull/4).
