### PR TITLE
Fix enableMic/enableCam ignored during initDevices

### DIFF
--- a/transports/daily/src/transport.ts
+++ b/transports/daily/src/transport.ts
@@ -264,7 +264,10 @@ export class RNDailyTransport extends Transport {
     }
 
     this.state = 'initializing';
-    await this._daily.startCamera();
+    await this._daily.startCamera({
+      startVideoOff: this._dailyFactoryOptions.startVideoOff,
+      startAudioOff: this._dailyFactoryOptions.startAudioOff,
+    });
     const { devices } = await this._daily.enumerateDevices();
     const cams = devices.filter((d) => d.kind === 'videoinput');
     const mics = devices.filter((d) => d.kind === 'audio');


### PR DESCRIPTION
## Summary

- Fixes `enableMic: false` and `enableCam: false` being ignored during device initialization, causing the mic/camera hardware to activate immediately on connection
- Passes `startAudioOff` and `startVideoOff` options from `_dailyFactoryOptions` to Daily's `startCamera()` call in `initDevices()`

Fixes #24

## Root Cause

`RNDailyTransport.initDevices()` called `this._daily.startCamera()` with no arguments, so the Daily SDK used its defaults and started both mic and camera hardware. The `enableMic`/`enableCam` options were correctly mapped to `startAudioOff`/`startVideoOff` in `initialize()`, but never forwarded to `startCamera()`.

The `DailyMediaManager` (used by `SmallWebRTCTransport`) already handled this correctly by passing the options explicitly.

## Test plan

- [ ] Create a `PipecatClient` with `enableMic: false, enableCam: false` and verify the OS mic/camera indicators do **not** appear on connection
- [ ] Verify that calling `client.enableMic(true)` after connection correctly activates the mic
- [ ] Verify that the default behavior (`enableMic: true`) still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)