### PR TITLE
Making React Native transports compatible with the pipecat client 1.6.0 spec

### DIFF
--- a/transports/daily/CHANGELOG.md
+++ b/transports/daily/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to **Pipecat Client React Native** will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - Unreleased
+
+### Added
+
+- `_maxMessageSize` introduced to `Transports` along with a `MessageTooLargeError` for
+  proper handling of attempts to send a message larger than what the transport can handle
+- Added support for new `llm-function-call-started`, `llm-function-call-in-progress`, and `llm-function-call-stopped` RTVI events with corresponding `onLLMFunctionCallStarted`, `onLLMFunctionCallInProgress`, and `onLLMFunctionCallStopped` callbacks. These events optionally include metadata about the function call that triggered them, as dictated by the server. See below: `onLLMFunctionCallInProgress` should be used in lieu of the now deprecated `onLLMFunctionCall` callback.
+- Added support for new `user-mute-started` and `user-mute-stopped` RTVI events with corresponding `onUserMuteStarted` and `onUserMuteStopped` callbacks. These events notify when the server is ignoring audio from the client (server-side muting). The client should continue sending audio normally but may want to show some indication to the user.
+
+### Changed
+
+- Updated RTVI Version to 1.2.0 to indicate recent changes:
+  - New Message Support: `send-text`, `bot-output`, function call events, user mute events
+  - Deprecated Messages: `append-to-context`, `bot-transcription`, and `llm-function-call`
+
+### Fixed
+
+- Fixed a bug where the transport would not initialize devices when starting a bot if the transport was already disconnected.
+
+### Deprecated
+
+- Per the introduction of the more thorough set of function call events, `onLLMFunctionCall` has been deprecated and replaced by `onLLMFunctionCallInProgress`. The existence of the `function_name` and `args` in the data provided is determined by the server as a security measure. Note that the `FunctionCallHandler`s are still valid and are now triggered from `llm-function-call-in-progress` events that include a `function_name`. These callbacks are specifically meant for returning data to the server that is needed to resolve the function call (ex. getting the location of the client to resolve a get_weather function call).
+
 ## [1.5.0] - 2026-01-14
 
 ### Added

--- a/transports/daily/package.json
+++ b/transports/daily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipecat-ai/react-native-daily-transport",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "BSD-2-Clause",
   "description": "React Native library for connecting to RTVI client using Daily",
   "main": "./lib/commonjs/index.js",
@@ -71,7 +71,7 @@
     ]
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.5.0"
+    "@pipecat-ai/client-js": "^1.6.0"
   },
   "peerDependencies": {
     "@daily-co/react-native-daily-js": "^0.82.0",

--- a/transports/daily/src/transport.ts
+++ b/transports/daily/src/transport.ts
@@ -15,6 +15,7 @@ import Daily, {
   DailyEventObjectTrack,
   DailyFactoryOptions,
   DailyParticipant,
+  DailyRoomInfo,
 } from '@daily-co/react-native-daily-js';
 
 import {
@@ -30,6 +31,7 @@ import {
   TransportStartError,
   TransportState,
   logger,
+  MessageTooLargeError,
 } from '@pipecat-ai/client-js';
 import { MediaDeviceInfo } from '@daily-co/react-native-webrtc';
 
@@ -264,10 +266,7 @@ export class RNDailyTransport extends Transport {
     }
 
     this.state = 'initializing';
-    await this._daily.startCamera({
-      startVideoOff: this._dailyFactoryOptions.startVideoOff,
-      startAudioOff: this._dailyFactoryOptions.startAudioOff,
-    });
+    await this._daily.startCamera(this._dailyFactoryOptions);
     const { devices } = await this._daily.enumerateDevices();
     const cams = devices.filter((d) => d.kind === 'videoinput');
     const mics = devices.filter((d) => d.kind === 'audio');
@@ -347,6 +346,12 @@ export class RNDailyTransport extends Transport {
 
     if (this._abortController?.signal.aborted) return;
 
+    const r = await this._daily.room();
+    this._maxMessageSize =
+      // @ts-ignore
+      (r as DailyRoomInfo)?.domainConfig?.max_app_message_size ||
+      10 * 1024 * 1024;
+
     this.state = 'connected';
 
     this._callbacks.onConnected?.();
@@ -406,7 +411,17 @@ export class RNDailyTransport extends Transport {
   }
 
   public sendMessage(message: RTVIMessage) {
-    this._daily.sendAppMessage(message, '*');
+    try {
+      this._daily.sendAppMessage(message, '*');
+    } catch (error: unknown) {
+      if (
+        error instanceof Error &&
+        error.message.includes('Message data too large')
+      ) {
+        throw new MessageTooLargeError(error.message);
+      }
+      throw error;
+    }
   }
 
   private handleAppMessage(ev: DailyEventObjectAppMessage) {

--- a/transports/smallwebrtc/CHANGELOG.md
+++ b/transports/smallwebrtc/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to **Pipecat Client React Native Small WebRTC** will be docu
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - Unreleased
+
+### Added
+
+- `_maxMessageSize` introduced to `Transports` along with a `MessageTooLargeError` for
+  proper handling of attempts to send a message larger than what the transport can handle
+- Added support for new `llm-function-call-started`, `llm-function-call-in-progress`, and `llm-function-call-stopped` RTVI events with corresponding `onLLMFunctionCallStarted`, `onLLMFunctionCallInProgress`, and `onLLMFunctionCallStopped` callbacks. These events optionally include metadata about the function call that triggered them, as dictated by the server. See below: `onLLMFunctionCallInProgress` should be used in lieu of the now deprecated `onLLMFunctionCall` callback.
+- Added support for new `user-mute-started` and `user-mute-stopped` RTVI events with corresponding `onUserMuteStarted` and `onUserMuteStopped` callbacks. These events notify when the server is ignoring audio from the client (server-side muting). The client should continue sending audio normally but may want to show some indication to the user.
+
+### Changed
+
+- Updated RTVI Version to 1.2.0 to indicate recent changes:
+  - New Message Support: `send-text`, `bot-output`, function call events, user mute events
+  - Deprecated Messages: `append-to-context`, `bot-transcription`, and `llm-function-call`
+
+### Fixed
+
+- Fixed a bug where the transport would not initialize devices when starting a bot if the transport was already disconnected.
+
+### Deprecated
+
+- Per the introduction of the more thorough set of function call events, `onLLMFunctionCall` has been deprecated and replaced by `onLLMFunctionCallInProgress`. The existence of the `function_name` and `args` in the data provided is determined by the server as a security measure. Note that the `FunctionCallHandler`s are still valid and are now triggered from `llm-function-call-in-progress` events that include a `function_name`. These callbacks are specifically meant for returning data to the server that is needed to resolve the function call (ex. getting the location of the client to resolve a get_weather function call).
+
 ## [1.5.0] - 2026-01-14
 
 ### Added

--- a/transports/smallwebrtc/package.json
+++ b/transports/smallwebrtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipecat-ai/react-native-small-webrtc-transport",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "BSD-2-Clause",
   "description": "React Native library for connecting to RTVI client using Small WebRTC",
   "main": "./lib/commonjs/index.js",
@@ -70,7 +70,7 @@
     ]
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.5.0",
+    "@pipecat-ai/client-js": "^1.6.0",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {

--- a/transports/smallwebrtc/src/transport.ts
+++ b/transports/smallwebrtc/src/transport.ts
@@ -12,6 +12,8 @@ import {
   UnsupportedFeatureError,
   APIRequest,
   isAPIRequest,
+  messageSizeWithinLimit,
+  MessageTooLargeError,
 } from '@pipecat-ai/client-js';
 import { MediaManager, TrackEvent } from './media-manager/mediaManager';
 import {
@@ -428,6 +430,14 @@ export class RNSmallWebRTCTransport extends Transport {
       logger.warn(`Datachannel is not ready. Message not sent: ${message}`);
       return;
     }
+
+    // Note: This shouldn't happen since client-js should have already checked this
+    if (!messageSizeWithinLimit(message, this._maxMessageSize)) {
+      throw new MessageTooLargeError(
+        'Message data too large. Max size is ' + this._maxMessageSize
+      );
+    }
+
     this.dc?.send(JSON.stringify(message));
   }
 
@@ -907,6 +917,10 @@ export class RNSmallWebRTCTransport extends Transport {
     // @ts-ignore
     dc.addEventListener('open', () => {
       logger.debug('datachannel opened');
+      // using default value here since react-native-webrtc does not expose this.pc?.sctp?.maxMessageSize
+      // we may inspect SDP in the future if needed and look for a=max-message-size:
+      // But for now, this is the default value which aiortc provides from server side.
+      this._maxMessageSize = 64 * 1024;
       if (this._connectResolved) {
         this.syncTrackStatus();
         this._connectResolved();

--- a/types/@pipecat-ai/client-js/typeOverrides.d.ts
+++ b/types/@pipecat-ai/client-js/typeOverrides.d.ts
@@ -63,6 +63,9 @@ export class UnsupportedFeatureError extends RTVIError {
   readonly feature: string;
   constructor(feature: string, source?: string, message?: string);
 }
+export class MessageTooLargeError extends RTVIError {
+  constructor(message?: string | undefined);
+}
 export type DeviceArray = Array<'cam' | 'mic' | 'speaker'>;
 export type DeviceErrorType =
   | 'in-use'
@@ -86,7 +89,7 @@ export class DeviceError extends RTVIError {
     details?: DeviceErrorDetails
   );
 }
-export const RTVI_PROTOCOL_VERSION = '1.1.0';
+export const RTVI_PROTOCOL_VERSION = '1.2.0';
 export const RTVI_MESSAGE_LABEL = 'rtvi-ai';
 /**
  * Messages the corresponding server-side client expects to receive about
@@ -111,20 +114,25 @@ export enum RTVIMessageType {
   SERVER_RESPONSE = 'server-response', // Server response to client message
   ERROR_RESPONSE = 'error-response', // Error message in response to an outbound message
   APPEND_TO_CONTEXT_RESULT = 'append-to-context-result', // Result of appending to context
-  /** Transcription Messages */
-  USER_TRANSCRIPTION = 'user-transcription', // Local user speech to text transcription (partials and finals)
-  BOT_OUTPUT = 'bot-output', // A best effort aggregation of all bot output along with metadata like if it's spoken
-  BOT_TRANSCRIPTION = 'bot-transcription', // Bot full text transcription (sentence aggregated)
+  /** Speaking and Transcription Messages */
   USER_STARTED_SPEAKING = 'user-started-speaking', // User started speaking
   USER_STOPPED_SPEAKING = 'user-stopped-speaking', // User stopped speaking
   BOT_STARTED_SPEAKING = 'bot-started-speaking', // Bot started speaking
   BOT_STOPPED_SPEAKING = 'bot-stopped-speaking', // Bot stopped speaking
+  USER_MUTE_STARTED = 'user-mute-started', // User muted server-side.
+  USER_MUTE_STOPPED = 'user-mute-stopped', // User unmuted server-side.
+  USER_TRANSCRIPTION = 'user-transcription', // Local user speech to text transcription (partials and finals)
+  BOT_OUTPUT = 'bot-output', // A best effort aggregation of all bot output along with metadata like if it's spoken
+  BOT_TRANSCRIPTION = 'bot-transcription', // Bot full text transcription (sentence aggregated)
   /** LLM Messages */
   USER_LLM_TEXT = 'user-llm-text', // Aggregated user input text which is sent to LLM
   BOT_LLM_TEXT = 'bot-llm-text', // Streamed token returned by the LLM
   BOT_LLM_STARTED = 'bot-llm-started', // Bot LLM inference starts
   BOT_LLM_STOPPED = 'bot-llm-stopped', // Bot LLM inference stops
   LLM_FUNCTION_CALL = 'llm-function-call', // Inbound function call from LLM
+  LLM_FUNCTION_CALL_STARTED = 'llm-function-call-started', // Inbound function call started
+  LLM_FUNCTION_CALL_IN_PROGRESS = 'llm-function-call-in-progress', // Inbound function call in progress
+  LLM_FUNCTION_CALL_STOPPED = 'llm-function-call-stopped', // Inbound function call stopped
   LLM_FUNCTION_CALL_RESULT = 'llm-function-call-result', // Outbound result of function call
   BOT_LLM_SEARCH_RESPONSE = 'bot-llm-search-response', // Bot LLM search response
   /** TTS Messages */
@@ -206,8 +214,17 @@ export type LLMSearchOrigin = {
   site_title?: string;
   results: LLMSearchResult[];
 };
+export type LLMFunctionCallStartedData = {
+  function_name?: string;
+};
+export type LLMFunctionCallInProgressData = {
+  function_name?: string;
+  tool_call_id: string;
+  arguments?: Record<string, unknown>;
+};
+/** @deprecated Use LLMFunctionCallInProgressData instead */
 export type LLMFunctionCallData = {
-  function_name: string;
+  function_name?: string;
   tool_call_id: string;
   args: Record<string, unknown>;
 };
@@ -215,8 +232,14 @@ export type LLMFunctionCallResult = Record<string, unknown> | string;
 export type LLMFunctionCallResultResponse = {
   function_name: string;
   tool_call_id: string;
-  args: Record<string, unknown>;
+  arguments: Record<string, unknown>;
   result: LLMFunctionCallResult;
+};
+export type LLMFunctionCallStoppedData = {
+  function_name?: string;
+  tool_call_id: string;
+  cancelled: boolean;
+  result?: unknown;
 };
 export type SendTextOptions = {
   run_immediately?: boolean;
@@ -264,6 +287,8 @@ export enum RTVIEvent {
   BotStoppedSpeaking = 'botStoppedSpeaking',
   UserStartedSpeaking = 'userStartedSpeaking',
   UserStoppedSpeaking = 'userStoppedSpeaking',
+  UserMuteStarted = 'userMuteStarted',
+  UserMuteStopped = 'userMuteStopped',
   UserTranscript = 'userTranscript',
   BotOutput = 'botOutput',
   BotTranscript = 'botTranscript',
@@ -271,6 +296,9 @@ export enum RTVIEvent {
   BotLlmStarted = 'botLlmStarted',
   BotLlmStopped = 'botLlmStopped',
   LLMFunctionCall = 'llmFunctionCall',
+  LLMFunctionCallStarted = 'llmFunctionCallStarted',
+  LLMFunctionCallInProgress = 'llmFunctionCallInProgress',
+  LLMFunctionCallStopped = 'llmFunctionCallStopped',
   BotLlmSearchResponse = 'botLlmSearchResponse',
   BotTtsText = 'botTtsText',
   BotTtsStarted = 'botTtsStarted',
@@ -316,13 +344,19 @@ export type RTVIEvents = Partial<{
   botStoppedSpeaking: () => void;
   userStartedSpeaking: () => void;
   userStoppedSpeaking: () => void;
+  userMuteStarted: () => void;
+  userMuteStopped: () => void;
   userTranscript: (data: TranscriptData) => void;
   botOutput: (data: BotOutputData) => void;
   botTranscript: (data: BotLLMTextData) => void;
   botLlmText: (data: BotLLMTextData) => void;
   botLlmStarted: () => void;
   botLlmStopped: () => void;
+  /** @deprecated Use LLMFunctionCallInProgress instead */
   llmFunctionCall: (func: LLMFunctionCallData) => void;
+  llmFunctionCallStarted: (data: LLMFunctionCallStartedData) => void;
+  llmFunctionCallInProgress: (data: LLMFunctionCallInProgressData) => void;
+  llmFunctionCallStopped: (data: LLMFunctionCallStoppedData) => void;
   botLlmSearchResponse: (data: BotLLMSearchResponseData) => void;
   botTtsText: (data: BotTTSTextData) => void;
   botTtsStarted: () => void;
@@ -439,6 +473,19 @@ export abstract class Transport {
   protected _abortController: AbortController | undefined;
   protected _state: TransportState;
   protected _startBotParams: APIRequest | undefined;
+  /**
+   * Maximum allowed size in bytes for a single signaling/message payload.
+   *
+   * The default is 64 KiB (`64 * 1024`), which is chosen to stay well within
+   * typical WebSocket, proxy, and intermediary limits and to discourage
+   * transports from sending very large payloads in a single message.
+   *
+   * Transport implementations may override this value in subclasses or
+   * constructors if their underlying transport has stricter or more relaxed
+   * limits, as long as they continue to honor this field when enforcing
+   * message size constraints.
+   */
+  protected _maxMessageSize: number;
   constructor();
   /** called from PipecatClient constructor to wire up callbacks */
   abstract initialize(
@@ -495,6 +542,12 @@ export abstract class Transport {
   abstract get isMicEnabled(): boolean;
   abstract get isSharingScreen(): boolean;
   abstract sendMessage(message: RTVIMessage): void;
+  /**
+   * Maximum size, in bytes, of a single message that this transport will attempt
+   * to send. Callers should ensure that any outbound {@link RTVIMessage} payloads
+   * do not exceed this limit to avoid transport or server errors.
+   */
+  get maxMessageSize(): number;
   abstract tracks(): Tracks;
 }
 export class TransportWrapper {
@@ -516,6 +569,10 @@ interface JSAboutClientData extends AboutClientData {
   };
 }
 export function learnAboutClient(): JSAboutClientData;
+export function messageSizeWithinLimit(
+  message: unknown,
+  maxSize: number
+): boolean;
 export type FunctionCallParams = {
   functionName: string;
   arguments: Record<string, unknown>;
@@ -557,12 +614,15 @@ export type RTVIEventCallbacks = Partial<{
   onScreenShareError: (errorMessage: string) => void;
   onLocalAudioLevel: (level: number) => void;
   onRemoteAudioLevel: (level: number, participant: Participant) => void;
-  onBotStartedSpeaking: () => void;
-  onBotStoppedSpeaking: () => void;
   onUserStartedSpeaking: () => void;
   onUserStoppedSpeaking: () => void;
+  onBotStartedSpeaking: () => void;
+  onBotStoppedSpeaking: () => void;
+  onUserMuteStarted: () => void;
+  onUserMuteStopped: () => void;
   onUserTranscript: (data: TranscriptData) => void;
   onBotOutput: (data: BotOutputData) => void;
+  /** @deprecated Use onBotOutput instead */
   onBotTranscript: (data: BotLLMTextData) => void;
   onBotLlmText: (data: BotLLMTextData) => void;
   onBotLlmStarted: () => void;
@@ -570,8 +630,12 @@ export type RTVIEventCallbacks = Partial<{
   onBotTtsText: (data: BotTTSTextData) => void;
   onBotTtsStarted: () => void;
   onBotTtsStopped: () => void;
-  onLLMFunctionCall: (data: LLMFunctionCallData) => void;
+  onLLMFunctionCallStarted: (data: LLMFunctionCallStartedData) => void;
+  onLLMFunctionCallInProgress: (data: LLMFunctionCallInProgressData) => void;
+  onLLMFunctionCallStopped: (data: LLMFunctionCallStoppedData) => void;
   onBotLlmSearchResponse: (data: BotLLMSearchResponseData) => void;
+  /** @deprecated Use onLLMFunctionCallInProgress instead */
+  onLLMFunctionCall: (data: LLMFunctionCallData) => void;
 }>;
 export interface PipecatClientOptions {
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2654,9 +2654,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pipecat-ai/client-js@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@pipecat-ai/client-js@npm:1.5.0"
+"@pipecat-ai/client-js@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@pipecat-ai/client-js@npm:1.6.0"
   dependencies:
     "@types/events": ^3.0.3
     bowser: ^2.11.0
@@ -2664,7 +2664,7 @@ __metadata:
     events: ^3.3.0
     typed-emitter: ^2.1.0
     uuid: ^10.0.0
-  checksum: 09b65ba649adae2645344e3f87093dee4278f70dcf01e881724a7012f765847e7dc28ed14ae1538d57e0d190992b4095abf2275c71d9aa1ff6024308f759b556
+  checksum: 408cb2eea5bc6e597fb927153ff866269d48eb23964590a6be64a99d5076bb1f52051cddfb726e31f3a7439cc8bb7cf4e5d80da55b238836354d2dfc48f9cf91
   languageName: node
   linkType: hard
 
@@ -2724,7 +2724,7 @@ __metadata:
   dependencies:
     "@daily-co/react-native-daily-js": ^0.82.0
     "@daily-co/react-native-webrtc": ^124.0.6-daily.1
-    "@pipecat-ai/client-js": ^1.5.0
+    "@pipecat-ai/client-js": ^1.6.0
     "@react-native-async-storage/async-storage": ^1.24.0
     "@types/base-64": ^1.0.2
     del-cli: ^6.0.0
@@ -2774,7 +2774,7 @@ __metadata:
   resolution: "@pipecat-ai/react-native-small-webrtc-transport@workspace:transports/smallwebrtc"
   dependencies:
     "@daily-co/react-native-webrtc": ^124.0.6-daily.1
-    "@pipecat-ai/client-js": ^1.5.0
+    "@pipecat-ai/client-js": ^1.6.0
     "@types/base-64": ^1.0.2
     "@types/lodash": ^4.17.20
     "@types/react": 18.3.21


### PR DESCRIPTION
Making React Native transports compatible with the pipecat client 1.6.0 spec