### PR TITLE
Fix #28: Fix timing issue with client ready message

### DIFF
--- a/transports/daily/src/transport.ts
+++ b/transports/daily/src/transport.ts
@@ -359,15 +359,24 @@ export class RNDailyTransport extends Transport {
 
   async sendReadyMessage(): Promise<void> {
     return new Promise<void>((resolve) => {
-      (async () => {
-        this._daily.on('track-started', (ev) => {
-          if (!ev.participant?.local) {
-            this.state = 'ready';
-            this.sendMessage(RTVIMessage.clientReady());
-            resolve();
-          }
-        });
-      })();
+      for (const id in this._daily.participants()) {
+        const p = this._daily.participants()[id];
+        if (!p.local && p.tracks?.audio?.persistentTrack) {
+          // If we already have a remote audio track, we can send the ready message immediately
+          this.state = 'ready';
+          this.sendMessage(RTVIMessage.clientReady());
+          resolve();
+          return;
+        }
+      }
+      const readyHandler = (ev: DailyEventObjectTrack) => {
+        if (!ev.participant?.local) {
+          this.state = 'ready';
+          this.sendMessage(RTVIMessage.clientReady());
+          resolve();
+        }
+      };
+      this._daily.on('track-started', readyHandler);
     });
   }
 

--- a/transports/daily/src/transport.ts
+++ b/transports/daily/src/transport.ts
@@ -359,8 +359,9 @@ export class RNDailyTransport extends Transport {
 
   async sendReadyMessage(): Promise<void> {
     return new Promise<void>((resolve) => {
-      for (const id in this._daily.participants()) {
-        const p = this._daily.participants()[id];
+      const participants = this._daily.participants();
+      for (const id in participants) {
+        const p = participants[id];
         if (!p.local && p.tracks?.audio?.persistentTrack) {
           // If we already have a remote audio track, we can send the ready message immediately
           this.state = 'ready';
@@ -371,6 +372,7 @@ export class RNDailyTransport extends Transport {
       }
       const readyHandler = (ev: DailyEventObjectTrack) => {
         if (!ev.participant?.local) {
+          this._daily.off('track-started', readyHandler);
           this.state = 'ready';
           this.sendMessage(RTVIMessage.clientReady());
           resolve();


### PR DESCRIPTION
If the bot track came in before the client called sendReadyMessage, the message might never send, waiting on the track-started event.