### PR TITLE
Fixed a race condition where `RNSmallWebRTCTransport` could emit a null runtime error during React Native startup.

### DIFF
--- a/transports/daily/src/transport.ts
+++ b/transports/daily/src/transport.ts
@@ -362,7 +362,7 @@ export class RNDailyTransport extends Transport {
       const participants = this._daily.participants();
       for (const id in participants) {
         const p = participants[id];
-        if (!p.local && p.tracks?.audio?.persistentTrack) {
+        if (!p?.local && p?.tracks?.audio?.persistentTrack) {
           // If we already have a remote audio track, we can send the ready message immediately
           this.state = 'ready';
           this.sendMessage(RTVIMessage.clientReady());

--- a/transports/smallwebrtc/CHANGELOG.md
+++ b/transports/smallwebrtc/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to **Pipecat Client React Native Small WebRTC** will be docu
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fixed a race condition where `RNSmallWebRTCTransport` could emit a null runtime error during React Native startup.
+
 ## [1.6.0] - 2026-03-24
 
 ### Added

--- a/transports/smallwebrtc/src/transport.ts
+++ b/transports/smallwebrtc/src/transport.ts
@@ -155,6 +155,11 @@ export class RNSmallWebRTCTransport extends Transport {
   }
 
   private async _handleTrackStarted(event: TrackEvent) {
+    if (!this.pc) {
+      // If pc is not initialized yet, just return.
+      // The correct track will be handled once pc is initialized, inside addUserMedia.
+      return;
+    }
     if (event.type === 'audio') {
       logger.info('SmallWebRTCMediaManager replacing audio track');
       await this.getAudioTransceiver()?.sender.replaceTrack(event.track);
@@ -794,19 +799,19 @@ export class RNSmallWebRTCTransport extends Transport {
   private getAudioTransceiver() {
     // Transceivers always appear in creation-order for both peers
     // Look at addInitialTransceivers
-    return this.pc!.getTransceivers()[AUDIO_TRANSCEIVER_INDEX];
+    return this.pc?.getTransceivers()[AUDIO_TRANSCEIVER_INDEX];
   }
 
   private getVideoTransceiver() {
     // Transceivers always appear in creation-order for both peers
     // Look at addInitialTransceivers
-    return this.pc!.getTransceivers()[VIDEO_TRANSCEIVER_INDEX];
+    return this.pc?.getTransceivers()[VIDEO_TRANSCEIVER_INDEX];
   }
 
   private getScreenVideoTransceiver() {
     // Transceivers always appear in creation-order for both peers
     // Look at addInitialTransceivers
-    return this.pc!.getTransceivers()[SCREEN_VIDEO_TRANSCEIVER_INDEX];
+    return this.pc?.getTransceivers()[SCREEN_VIDEO_TRANSCEIVER_INDEX];
   }
 
   private async startNewPeerConnection(


### PR DESCRIPTION
Fixed a race condition where `RNSmallWebRTCTransport` could emit a null runtime error during React Native startup.

Fixes https://github.com/pipecat-ai/pipecat-client-react-native-transports/issues/30